### PR TITLE
Adapt code to normalizr v3

### DIFF
--- a/lib/store/api.js
+++ b/lib/store/api.js
@@ -1,4 +1,4 @@
-import { Schema, arrayOf, normalize } from 'normalizr'
+import { schema, normalize } from 'normalizr';
 import { camelizeKeys } from 'humps'
 import { Middleware } from 'meteor/nova:lib'
 import thunk from 'redux-thunk'
@@ -35,36 +35,36 @@ const callApi = (endpoint, schema) => {
 // and keep it updated as we fetch more data.
 
 // Read more about Normalizr: https://github.com/paularmstrong/normalizr
-const confSchema = new Schema('config', {
+const confSchema = new schema.Entity('config', {
   idAttribute: config => config.id,
 })
 
-const compSchema = new Schema('comp', {
+const compSchema = new schema.Entity('comp', {
   idAttribute: comp => comp.id,
 })
 
-const roundSchema = new Schema('rounds', {
+const roundSchema = new schema.Entity('rounds', {
   idAttribute: round => round.id,
 })
 
-const matchSchema = new Schema ('matches', {
+const matchSchema = new schema.Entity ('matches', {
   idAttribute: match => match.id,
 })
 
-const teamSchema = new Schema ('teams', {
+const teamSchema = new schema.Entity ('teams', {
   idAttribute: team => team.id,
 })
 
-const matchResultSchema = new Schema ('simpleScoreMatchResults', {
+const matchResultSchema = new schema.Entity ('simpleScoreMatchResults', {
     idAttribute: simpleScoreMatchResult => simpleScoreMatchResult.id
 })
 
 compSchema.define({
-  rounds: arrayOf(roundSchema),
+  rounds: [roundSchema],
 })
 
 roundSchema.define({
-  matches: arrayOf(matchSchema),
+  matches: [matchSchema],
 })
 
 matchSchema.define({
@@ -80,9 +80,9 @@ export const Schemas = {
   CONF: confSchema,
   COMP: compSchema,
   ROUND: roundSchema,
-  ROUND_ARRAY: arrayOf(roundSchema),
+  ROUND_ARRAY: [roundSchema],
   MATCH: matchSchema,
-  MATCH_ARRAY: arrayOf(matchSchema)
+  MATCH_ARRAY: [matchSchema]
 }
 
 // Action key that carries API call info interpreted by this Redux middleware.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/dominictracey/trn-rest-redux",
   "dependencies": {
     "humps": "^2.0.0",
-    "normalizr": "^2.3.1",
+    "normalizr": "^3.0.0",
     "react-redux": "^5.0.1",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0"


### PR DESCRIPTION
Got Nova + your packages working... only after updating `normalizr` and the related code! 🤔 

Even when forcing `normalizr@2.3.1`, I had errors on build 😶 

I've adapted the code of the package to work with the latest version of `normalizr`, updated few days ago. The data remains the same in the redux store, like you have shown me on our sprint initiation 👍 

https://github.com/paularmstrong/normalizr/releases/tag/v3.0.0